### PR TITLE
Update link for Linux Lazy Newb Pack

### DIFF
--- a/_data/packs.json
+++ b/_data/packs.json
@@ -20,10 +20,10 @@
     {
         "id": "linux-be",
         "platform": "Linux",
-        "name": "Beautato's Linux Pack",
-        "author_name": "Beautato",
-        "author_img": "http://i.imgur.com/8dd9YLs.jpg",
-        "bay12_thread": "128960",
-        "url": "http://lazynewbpack.com/linux/"
+        "name": "(See Dwarf Fortress Wiki)",
+        "author_name": "n/a",
+        "author_img": "https://www.dwarffortresswiki.org/images/d/d4/WikiLogo_4fa619.png",
+        "bay12_thread": "n/a",
+        "url": "https://www.dwarffortresswiki.org/index.php/Utility:Lazy_Newb_Pack"
     }
 ]


### PR DESCRIPTION
Changed the link from lazynewbpack.com as this domain has been hijacked and redirects to malware; removed references to Beautato pack. 

It seems beautato's pack hasn't been updated for 6 years, so I've included a link to the Wiki instead where there are 2 current forks of LNPs for Linux. 

If you wanted to pick one and direct-link in the same way as the Mac and Windows links, the LinuxDwarfPack is currently the more up to date of the two, but I primarily wanted to remove the dodgy link.